### PR TITLE
Implement default light theme with tailwind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "NutriTrackWeb",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@tailwindcss/cli": "^4.1.13",
-        "tailwindcss": "^4.1.13"
+        "tailwindcss": "^4.1.14"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -358,6 +358,12 @@
         "tailwindcss": "dist/index.mjs"
       }
     },
+    "node_modules/@tailwindcss/cli/node_modules/tailwindcss": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.13.tgz",
@@ -371,6 +377,12 @@
         "source-map-js": "^1.2.1",
         "tailwindcss": "4.1.13"
       }
+    },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
+      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.1.13",
@@ -995,9 +1007,10 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
-      "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w=="
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
+      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "@tailwindcss/cli": "^4.1.13",
-    "tailwindcss": "^4.1.13"
+    "tailwindcss": "^4.1.14"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -50,10 +50,10 @@
                 </div>
                 <ul class="hidden md:flex items-center space-x-8">
                     <li><a href="#"
-                            class="hover:bg-light-text hover:text-white transition duration-200 transform hover:scale-105">Home</a>
+                            class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition duration-200 transform hover:scale-105">Home</a>
                     </li>
                     <li><a href="#"
-                            class="hover:text-light-text dark:text-gray-300 dark:hover:text-white transition duration-200 transform hover:scale-105">About
+                            class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition duration-200 transform hover:scale-105">About
                             Us</a></li>
                     <li><a href="#"
                             class="text-gray-600 hover:text-gray-950 dark:text-gray-300 dark:hover:text-white transition duration-200 transform hover:scale-105">Features</a>
@@ -67,7 +67,7 @@
                 </ul>
                 <div class="hidden md:flex items-center space-x-3">
                     <a href="signin.html"
-                        class="dark:text-dark-text whitespace-nowrap transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none w-full">
+                        class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white whitespace-nowrap transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none w-full">
                         Sign In
                     </a>
                     <a href="signup.html"
@@ -91,7 +91,7 @@
     <!-- Main -->
     <main>
         <!-- Hero Section -->
-        <section class="py-16 md:py-32 h-[750px] relative overflow-hidden shadow-sm bg-light-bg dark:bg-dark-bg">
+        <section class="py-16 md:py-32 h-[750px] relative overflow-hidden shadow-sm bg-white dark:bg-dark-bg">
             <div class="absolute inset-0 opacity-60"></div>
             <div class="container mx-auto px-6 relative z-10">
                 <!-- Konten Hero -->
@@ -99,7 +99,7 @@
         </section>
 
         <!-- Why NutriTrack Section -->
-        <section class="relative text-center py-16 sm:py-32 overflow-hidden bg-light-bg dark:bg-dark-bg">
+        <section class="relative text-center py-16 sm:py-32 overflow-hidden bg-white dark:bg-dark-bg">
             <div aria-hidden="true" class="absolute inset-0 z-0">
                 <div
                     class="absolute bottom-0 left-0 inset-y-1/4 w-96 h-96 bg-purple-300 rounded-full mix-blend-multiply filter blur-3xl opacity-40 animate-blob">
@@ -112,7 +112,7 @@
             <div class="relative z-10">
                 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div class="text-center mb-6 md:mb-0">
-                        <h2 class="text-4xl sm:text-5xl font-bold tracking-tight text-light-text dark:text-dark-text">
+                        <h2 class="text-4xl sm:text-5xl font-bold tracking-tight text-gray-900 dark:text-dark-text">
                             Why NutriTrack ?
                         </h2>
                         <p class="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
@@ -121,7 +121,7 @@
                     </div>
                     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         <div
-                            class="mt-12 max-w-6xl mx-auto h-[550px] bg-light-card dark:bg-dark-card rounded-lg shadow-md border border-light-border dark:border-dark-border">
+                            class="mt-12 max-w-6xl mx-auto h-[550px] bg-white dark:bg-dark-card rounded-lg shadow-md border border-gray-200 dark:border-dark-border">
                         </div>
                     </div>
                 </div>
@@ -129,13 +129,13 @@
         </section>
 
         <!-- See NutriTrack in Action Section -->
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 bg-light-bg dark:bg-dark-bg">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 bg-white dark:bg-dark-bg">
             <section class="py-16 sm:py-24">
                 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div class="flex flex-col md:flex-row items-center justify-between mb-12 sm:mb-16">
                         <div class="text-center md:text-left mb-6 md:mb-0">
                             <h2
-                                class="text-4xl sm:text-5xl font-bold tracking-tight text-light-text dark:text-dark-text">
+                                class="text-4xl sm:text-5xl font-bold tracking-tight text-gray-900 dark:text-dark-text">
                                 See NutriTrack in Action</h2>
                             <p class="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl">
                                 Dive into our core functionalities tailored for your goals.
@@ -149,13 +149,13 @@
 
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
                         <div
-                            class="h-[500px] bg-light-card dark:bg-dark-card rounded-lg shadow-md border border-light-border dark:border-dark-border">
+                            class="h-[500px] bg-white dark:bg-dark-card rounded-lg shadow-md border border-gray-200 dark:border-dark-border">
                         </div>
                         <div
-                            class="h-[500px] bg-light-card dark:bg-dark-card rounded-lg shadow-md border border-light-border dark:border-dark-border">
+                            class="h-[500px] bg-white dark:bg-dark-card rounded-lg shadow-md border border-gray-200 dark:border-dark-border">
                         </div>
                         <div
-                            class="h-[500px] bg-light-card dark:bg-dark-card rounded-lg shadow-md border border-light-border dark:border-dark-border">
+                            class="h-[500px] bg-white dark:bg-dark-card rounded-lg shadow-md border border-gray-200 dark:border-dark-border">
                         </div>
                     </div>
                 </div>
@@ -165,7 +165,7 @@
             <section class="py-16 sm:py-24">
                 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                     <div class="text-center mb-6 md:mb-0">
-                        <h2 class="text-4xl sm:text-5xl font-bold tracking-tight text-light-text dark:text-dark-text">
+                        <h2 class="text-4xl sm:text-5xl font-bold tracking-tight text-gray-900 dark:text-dark-text">
                             Riview</h2>
                         <p class="mt-3 text-lg text-gray-600 dark:text-gray-300 max-w-xl mx-auto">
                             What are they saying about us?
@@ -174,46 +174,46 @@
                     <div class="mt-12 grid grid-cols-2 md:grid-cols-4 gap-4 sm:gap-6">
                         <div class="space-y-4 sm:space-y-6">
                             <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
-                            </div>
-                        </div>
-                        <div class="space-y-4 sm:space-y-6">
-                            <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
-                            </div>
-                            <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
-                            </div>
-                            <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                         </div>
                         <div class="space-y-4 sm:space-y-6">
                             <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                         </div>
                         <div class="space-y-4 sm:space-y-6">
                             <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-40 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                             <div
-                                class="h-56 bg-light-card dark:bg-dark-card rounded-lg border border-light-border dark:border-dark-border">
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
+                            </div>
+                        </div>
+                        <div class="space-y-4 sm:space-y-6">
+                            <div
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
+                            </div>
+                            <div
+                                class="h-40 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
+                            </div>
+                            <div
+                                class="h-56 bg-white dark:bg-dark-card rounded-lg border border-gray-200 dark:border-dark-border">
                             </div>
                         </div>
                     </div>
@@ -223,14 +223,14 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-light-bg dark:bg-dark-bg my-24 sm:py-24">
+    <footer class="bg-white dark:bg-dark-bg my-24 sm:py-24">
         <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
             <div class="grid grid-cols-2 md:grid-cols-5 gap-8 items-start">
                 <div class="space-y-4">
                     <a href="mailto:hi@nutritrack.com"
-                        class="text-lg hover:underline block text-light-text dark:text-dark-text">hi@nutritrack.com</a>
-                    <div class="flex space-x-4 text-light-text dark:text-dark-text">
-                        <a href="#" class="hover:bg-light-hover dark:hover:text-white">
+                        class="text-lg hover:underline block text-gray-900 dark:text-dark-text">hi@nutritrack.com</a>
+                    <div class="flex space-x-4 text-gray-900 dark:text-dark-text">
+                        <a href="#" class="hover:bg-gray-100 dark:hover:text-white">
                             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                                 stroke="currentColor" class="size-6">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -256,10 +256,10 @@
                 </div>
 
                 <div>
-                    <h4 class="font-medium text-light-text dark:text-dark-text">Product</h4>
+                    <h4 class="font-medium text-gray-900 dark:text-dark-text">Product</h4>
                     <ul class="mt-4 space-y-4 text-sm">
                         <li><a href="#"
-                                class="text-light-text hover:text-light-text dark:text-dark-text dark:hover:text-white">Home</a>
+                                class="text-light-text hover:text-gray-900 dark:text-dark-text dark:hover:text-white">Home</a>
                         </li>
                         <li><a href="#"
                                 class="text-light-text hover:text-gray-900 dark:text-dark-text dark:hover:text-white">Features</a>
@@ -271,7 +271,7 @@
                 </div>
 
                 <div>
-                    <h4 class="font-medium text-light-text dark:text-dark-text">Company</h4>
+                    <h4 class="font-medium text-gray-900 dark:text-dark-text">Company</h4>
                     <ul class="mt-4 space-y-4 text-sm">
                         <li><a href="#"
                                 class="text-light-text hover:text-gray-900 dark:text-dark-text dark:hover:text-white">4Ever
@@ -283,7 +283,7 @@
                 </div>
 
                 <div>
-                    <h4 class="font-medium text-light-text dark:text-dark-text">What Our Users Say</h4>
+                    <h4 class="font-medium text-gray-900 dark:text-dark-text">What Our Users Say</h4>
                     <ul class="mt-4 space-y-4 text-sm">
                         <li><a href="#"
                                 class="text-light-text hover:text-gray-900 dark:text-dark-text dark:hover:text-white">Riviews</a>
@@ -295,7 +295,7 @@
                     <div class="relative inline-block text-left w-full">
                         <div>
                             <button id="dropdownButton" type="button"
-                                class="inline-flex justify-start w-full rounded-md border border-light-border dark:border-dark-border shadow-sm px-4 py-2 bg-light-card dark:bg-dark-card text-sm font-medium text-light-text dark:text-dark-text hover:bg-light-hover dark:hover:bg-dark-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#000000]"
+                                class="inline-flex justify-start w-full rounded-md border border-gray-200 dark:border-dark-border shadow-sm px-4 py-2 bg-white dark:bg-dark-card text-sm font-medium text-gray-900 dark:text-dark-text hover:bg-gray-100 dark:hover:bg-dark-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#000000]"
                                 aria-expanded="true" aria-haspopup="true">
                                 Language
                                 <svg class="-mr-1 ml-auto h-5 w-5" xmlns="http://www.w3.org/2000/svg"
@@ -308,14 +308,14 @@
                         </div>
 
                         <div id="dropdownMenu"
-                            class="hidden origin-top-right absolute right-0 mt-2 w-auto rounded-md shadow-lg bg-light-card dark:bg-dark-card ring-1 ring-black ring-opacity-5 focus:outline-none fade-in"
+                            class="hidden origin-top-right absolute right-0 mt-2 w-auto rounded-md shadow-lg bg-white dark:bg-dark-card ring-1 ring-black ring-opacity-5 focus:outline-none fade-in"
                             role="menu" aria-orientation="vertical" aria-labelledby="dropdownButton">
                             <div class="py-1" role="none">
                                 <a href="#"
-                                    class="text-light-text dark:text-dark-text block px-4 py-2 text-sm hover:bg-light-hover dark:hover:bg-dark-hover"
+                                    class="text-gray-900 dark:text-dark-text block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-hover"
                                     role="menuitem">English</a>
                                 <a href="#"
-                                    class="text-light-text dark:text-dark-text block px-4 py-2 text-sm hover:bg-light-hover dark:hover:bg-dark-hover"
+                                    class="text-gray-900 dark:text-dark-text block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-dark-hover"
                                     role="menuitem">Bahasa Indonesia</a>
                             </div>
                         </div>
@@ -323,7 +323,7 @@
 
                     <div class="flex space-x-2">
                         <div id="theme-switcher"
-                            class="flex p-1 rounded-full border border-light-border dark:border-dark-border shadow-sm bg-light-card dark:bg-dark-card">
+                            class="flex p-1 rounded-full border border-gray-200 dark:border-dark-border shadow-sm bg-white dark:bg-dark-card">
                             <button id="system-btn"
                                 class="flex items-center justify-center p-2 rounded-full transition-colors duration-200">
                                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
@@ -441,10 +441,10 @@
 
         window.addEventListener('scroll', () => {
             if (window.scrollY > scrollThreshold) {
-                header.classList.add('bg-light-bg', 'dark:bg-dark-bg', 'shadow-lg', 'backdrop-blur-sm', 'bg-opacity-80', 'py-4');
+                header.classList.add('bg-white', 'dark:bg-dark-bg', 'shadow-lg', 'backdrop-blur-sm', 'bg-opacity-80', 'py-4');
                 header.classList.remove('py-6');
             } else {
-                header.classList.remove('bg-light-bg', 'dark:bg-dark-bg', 'shadow-lg', 'backdrop-blur-sm', 'bg-opacity-80', 'py-4');
+                header.classList.remove('bg-white', 'dark:bg-dark-bg', 'shadow-lg', 'backdrop-blur-sm', 'bg-opacity-80', 'py-4');
                 header.classList.add('py-6');
             }
         });

--- a/src/input.css
+++ b/src/input.css
@@ -1,25 +1,19 @@
 @import "tailwindcss";
 
 @layer base {
-  :root {
-    --light-bg: #f5f5f5;
+  /* Hanya definisikan CSS variables untuk dark theme */
+  .dark {
     --dark-bg: #1c1c1c;
-    --light-text: #1f2937;
     --dark-text: #f5f5f5;
-    --light-card: #ffffff;
     --dark-card: #2a2a2a;
-    --light-border: #cccccc;
     --dark-border: #404040;
-    --light-hover: #ff0000;
     --dark-hover: #374151;
-    --light-active: #ffffff;
     --dark-active: #34373b;
-    --light-inactive: #9ca3af;
     --dark-inactive: #6b7280;
   }
 
+  /* Light theme akan menggunakan default Tailwind colors */
   body {
-    background-color: var(--light-bg);
     transition: background-color 0.3s, color 0.3s;
   }
 
@@ -33,7 +27,7 @@
 
   /* Button styles untuk theme switcher */
   .btn-inactive {
-    color: var(--light-inactive);
+    color: #9ca3af; /* gray-400 */
   }
 
   .dark .btn-inactive {
@@ -41,8 +35,8 @@
   }
 
   .btn-active {
-    background-color: var(--light-active);
-    color: var(--light-text);
+    background-color: #ffffff; /* white */
+    color: #1f2937; /* gray-800 */
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   }
 
@@ -54,8 +48,8 @@
 
   /* Card styles */
   .card {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+    background-color: #ffffff; /* white */
+    border: 1px solid #e5e7eb; /* gray-200 */
     padding: 1.5rem;
     border-radius: 0.75rem;
     box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
@@ -73,7 +67,7 @@
   }
 
   .hover-card:hover {
-    background-color: var(--light-hover);
+    background-color: #f3f4f6; /* gray-100 */
   }
 
   .dark .hover-card:hover {

--- a/src/output.css
+++ b/src/output.css
@@ -14,6 +14,7 @@
     --color-purple-300: oklch(82.7% 0.119 306.383);
     --color-pink-300: oklch(82.3% 0.12 346.018);
     --color-gray-50: oklch(98.5% 0.002 247.839);
+    --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
     --color-gray-300: oklch(87.2% 0.01 258.338);
     --color-gray-400: oklch(70.7% 0.022 261.325);
@@ -646,6 +647,9 @@
   .text-gray-800 {
     color: var(--color-gray-800);
   }
+  .text-gray-900 {
+    color: var(--color-gray-900);
+  }
   .text-indigo-600 {
     color: var(--color-indigo-600);
   }
@@ -754,6 +758,13 @@
       }
     }
   }
+  .hover\:bg-gray-100 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-gray-100);
+      }
+    }
+  }
   .hover\:bg-gray-700 {
     &:hover {
       @media (hover: hover) {
@@ -772,13 +783,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-gray-950);
-      }
-    }
-  }
-  .hover\:text-white {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-white);
       }
     }
   }
@@ -985,24 +989,16 @@
   }
 }
 @layer base {
-  :root {
-    --light-bg: #f5f5f5;
+  .dark {
     --dark-bg: #1c1c1c;
-    --light-text: #1f2937;
     --dark-text: #f5f5f5;
-    --light-card: #ffffff;
     --dark-card: #2a2a2a;
-    --light-border: #cccccc;
     --dark-border: #404040;
-    --light-hover: #ff0000;
     --dark-hover: #374151;
-    --light-active: #ffffff;
     --dark-active: #34373b;
-    --light-inactive: #9ca3af;
     --dark-inactive: #6b7280;
   }
   body {
-    background-color: var(--light-bg);
     transition: background-color 0.3s, color 0.3s;
   }
   .dark body {
@@ -1012,14 +1008,14 @@
 }
 @layer components {
   .btn-inactive {
-    color: var(--light-inactive);
+    color: #9ca3af;
   }
   .dark .btn-inactive {
     color: var(--dark-inactive);
   }
   .btn-active {
-    background-color: var(--light-active);
-    color: var(--light-text);
+    background-color: #ffffff;
+    color: #1f2937;
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   }
   .dark .btn-active {
@@ -1028,8 +1024,8 @@
     box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   }
   .card {
-    background-color: var(--light-card);
-    border: 1px solid var(--light-border);
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
     padding: 1.5rem;
     border-radius: 0.75rem;
     box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
@@ -1043,7 +1039,7 @@
     transition: all 0.2s ease-in-out;
   }
   .hover-card:hover {
-    background-color: var(--light-hover);
+    background-color: #f3f4f6;
   }
   .dark .hover-card:hover {
     background-color: var(--dark-hover);


### PR DESCRIPTION
Refactor light theme to use default Tailwind CSS classes and colors.

This change simplifies light theme styling by leveraging Tailwind's built-in utilities, as custom CSS variables were primarily defined for the dark theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b80fd9f-81f0-4c63-a8ca-8109370fc341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b80fd9f-81f0-4c63-a8ca-8109370fc341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

